### PR TITLE
feat: add ONLY_UPDATE_STARTED_APPS option to filter running apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `CRON_SCHEDULE` (_optional_): Cron schedule for when to check for updates (e.g., `0 4 * * *` for daily at 4 AM). If not set, the script will run once and then exit.
 - `APPRISE_URLS` (_optional_): Apprise URLs to send notifications to (e.g., `https://example.com/apprise,https://example.com/apprise2`) More info on [Apprise](https://github.com/caronc/apprise)
 - `NOTIFY_ON_SUCCESS` (_optional_): Set to "true" to receive notifications when apps are successfully updated (default: "false")
+- `ONLY_UPDATE_STARTED_APPS` (_optional_): Set to "true" to only update apps that are currently running/powered-on (default: "false"). This helps avoid unnecessary updates for apps that are stopped.
 - `EXCLUDE_APPS` (_optional_): Comma-separated list of app names to skip during updates (e.g., `app1,app2`). This is useful if you want to exclude certain apps from being updated automatically.
 - `INCLUDE_APPS` (_optional_): Comma-separated list of app names to include during updates (e.g., `app1,app2`). This is useful if you want to only update certain apps and skip the rest.
 
@@ -34,6 +35,7 @@ docker run --name truenas-auto-update \
          -e CRON_SCHEDULE="0 4 * * *" \
          -e APPRISE_URLS="https://example.com/apprise,https://example.com/apprise2" \
          -e NOTIFY_ON_SUCCESS="true" \
+         -e ONLY_UPDATE_STARTED_APPS="true" \
          ghcr.io/marvinvr/truenas-auto-update
 ```
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ BASE_URL = os.getenv("BASE_URL")
 API_KEY = os.getenv("API_KEY")
 APPRISE_URLS = os.getenv("APPRISE_URLS", "").strip()
 NOTIFY_ON_SUCCESS = os.getenv("NOTIFY_ON_SUCCESS", "false").lower() == "true"
+ONLY_UPDATE_STARTED_APPS = os.getenv("ONLY_UPDATE_STARTED_APPS", "false").lower() == "true"
 EXCLUDE_APPS = [app.strip() for app in os.getenv("EXCLUDE_APPS", "").strip().split(",") if app.strip()]
 INCLUDE_APPS = [app.strip() for app in os.getenv("INCLUDE_APPS", "").strip().split(",") if app.strip()]
 
@@ -84,6 +85,9 @@ for app in apps_with_upgrade:
         continue
     if INCLUDE_APPS and app["name"] not in INCLUDE_APPS:
         logger.info(f"Skipping upgrade for: {app['name']} (APP not in INCLUDE_APPS)")
+        continue
+    if ONLY_UPDATE_STARTED_APPS and app.get("state", "").upper() != "RUNNING":
+        logger.info(f"Skipping upgrade for: {app['name']} (APP not running, state: {app.get('state', 'unknown')})")
         continue
         
     logger.info(f"Upgrading {app['name']}...")


### PR DESCRIPTION
Implements feature request from issue #8 to add option for updating only powered-on apps.

## Changes
- Add `ONLY_UPDATE_STARTED_APPS` environment variable (defaults to false)
- Skip apps that are not in "RUNNING" state when option is enabled
- Update README.md with documentation and Docker example

## Testing
- Tested with TrueNAS SCALE v2.0 API
- Validates app `state` field and skips non-running apps
- Provides informative logging for skipped apps

Closes #8

Generated with [Claude Code](https://claude.ai/code)