### PR TITLE
feat: add SSL_VERIFY environment variable for configurable SSL certificate verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 BASE_URL=https://truenas.local
 API_KEY=your-api-key-here
 
+# SSL Configuration (Optional)
+# Set to true to enable SSL certificate verification
+# Recommended when using valid certificates like Let's Encrypt
+SSL_VERIFY=false
+
 # Cron Schedule (Optional)
 # Leave empty or comment out for run-once mode
 # Example: Run daily at 4 AM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ This is a simple Python application that automatically updates TrueNAS SCALE app
 - Implements notification system via Apprise library for multiple notification services
 - Supports both immediate execution and scheduled execution via cron
 - Job waiting mechanism for async upgrade operations using TrueNAS job system
-- SSL verification disabled for TrueNAS API calls (common for self-signed certificates)
+- Configurable SSL verification for TrueNAS API calls (disabled by default for self-signed certificates)
 
 ## Environment Configuration
 
@@ -31,6 +31,7 @@ Optional:
 - `CRON_SCHEDULE`: Cron expression for scheduling (if not set, runs once)
 - `APPRISE_URLS`: Comma-separated notification URLs
 - `NOTIFY_ON_SUCCESS`: Enable success notifications (default: false)
+- `SSL_VERIFY`: Enable SSL certificate verification (default: false)
 
 ## Development Commands
 
@@ -67,4 +68,4 @@ docker run --rm \
 - Uses TrueNAS `/app` endpoint to list apps and check `upgrade_available` flag
 - Triggers upgrades via `/app/upgrade` endpoint with app ID
 - Monitors upgrade progress using `/core/job_wait` endpoint for job completion
-- All API calls use Bearer token authentication and disable SSL verification
+- All API calls use Bearer token authentication with configurable SSL verification

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `ONLY_UPDATE_STARTED_APPS` (_optional_): Set to "true" to only update apps that are currently running/powered-on (default: "false"). This helps avoid unnecessary updates for apps that are stopped.
 - `EXCLUDE_APPS` (_optional_): Comma-separated list of app names to skip during updates (e.g., `app1,app2`). This is useful if you want to exclude certain apps from being updated automatically.
 - `INCLUDE_APPS` (_optional_): Comma-separated list of app names to include during updates (e.g., `app1,app2`). This is useful if you want to only update certain apps and skip the rest.
+- `SSL_VERIFY` (_optional_): Set to "true" to enable SSL certificate verification for TrueNAS API calls (default: "false"). When enabled, the connection will verify SSL certificates, which is recommended when using valid certificates like Let's Encrypt. When disabled, SSL warnings may be displayed but connections to TrueNAS instances with self-signed certificates will work.
 - `AUTO_CLEANUP_IMAGES` (_optional_): Set to "true" to automatically clean up unused Docker images after all updates are complete (default: "false"). This runs `docker image prune -a -f` to remove all unused images and free up disk space. **Requires the Docker socket to be mounted** (see Docker Image Cleanup section below).
 
 NOTE: The `EXCLUDE_APPS` and `INCLUDE_APPS` variables are mutually exclusive. If both are set, the application will error out.

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ APPRISE_URLS = os.getenv("APPRISE_URLS", "").strip()
 NOTIFY_ON_SUCCESS = os.getenv("NOTIFY_ON_SUCCESS", "false").lower() == "true"
 ONLY_UPDATE_STARTED_APPS = os.getenv("ONLY_UPDATE_STARTED_APPS", "false").lower() == "true"
 AUTO_CLEANUP_IMAGES = os.getenv("AUTO_CLEANUP_IMAGES", "false").lower() == "true"
+SSL_VERIFY = os.getenv("SSL_VERIFY", "false").lower() == "true"
 EXCLUDE_APPS = [app.strip() for app in os.getenv("EXCLUDE_APPS", "").strip().split(",") if app.strip()]
 INCLUDE_APPS = [app.strip() for app in os.getenv("INCLUDE_APPS", "").strip().split(",") if app.strip()]
 
@@ -113,7 +114,7 @@ BASE_URL = BASE_URL + "/api/v2.0"
 
 try:
     response = requests.get(
-        f"{BASE_URL}/app", headers={"Authorization": f"Bearer {API_KEY}"}, verify=False
+        f"{BASE_URL}/app", headers={"Authorization": f"Bearer {API_KEY}"}, verify=SSL_VERIFY
     )
 except Exception as e:
     logger.error(f"Failed to get apps: {str(e)}")
@@ -139,7 +140,7 @@ def await_job(job_id):
         f"{BASE_URL}/core/job_wait",
         headers={"Authorization": f"Bearer {API_KEY}"},
         json=job_id,
-        verify=False,
+        verify=SSL_VERIFY,
     )
 
     if job.status_code != 200:
@@ -165,7 +166,7 @@ for app in apps_with_upgrade:
         f"{BASE_URL}/app/upgrade",
         headers={"Authorization": f"Bearer {API_KEY}"},
         json={"app_name": app["id"]},
-        verify=False,
+        verify=SSL_VERIFY,
     )
 
     if response.status_code != 200:


### PR DESCRIPTION
This PR adds a configurable SSL_VERIFY environment variable to address SSL certificate verification warnings reported in issue #12.

## Changes
- Add SSL_VERIFY environment variable (defaults to false for compatibility)
- Update all TrueNAS API requests to use configurable SSL verification
- Update README.md, .env.example, and CLAUDE.md documentation

## Benefits
- Eliminates SSL certificate verification warnings for users with valid certificates (like Let’s Encrypt)
- Maintains backward compatibility with self-signed certificates (default behavior)
- Provides users with control over SSL verification behavior

Resolves #12

Generated with [Claude Code](https://claude.ai/code)