### PR TITLE
Add cron timezone configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM python:3.12-slim
 
 # Install required packages
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
     cron \
+    tzdata \
     gettext-base \
     ca-certificates \
     curl \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `API_KEY`: Your TrueNAS API key (see "Getting Started" for how to generate one)
 - `API_USERNAME` (_optional_): Username associated with the API key (default: `root`). **Required for TrueNAS 25.04+** where API keys are user-linked.
 - `CRON_SCHEDULE` (_optional_): Cron schedule for when to check for updates (e.g., `0 4 * * *` for daily at 4 AM). If not set, the script will run once and then exit.
+- `TZ` (_optional_): Timezone used by cron when evaluating `CRON_SCHEDULE` (e.g., `Europe/Zurich`). If not set, the container defaults to UTC.
 - `APPRISE_URLS` (_optional_): Apprise URLs to send notifications to (e.g., `https://example.com/apprise,https://example.com/apprise2`) More info on [Apprise](https://github.com/caronc/apprise)
 - `NOTIFY_ON_SUCCESS` (_optional_): Set to "true" to receive notifications when apps are successfully updated (default: "false")
 - `ONLY_UPDATE_STARTED_APPS` (_optional_): Set to "true" to only update apps that are currently running/powered-on (default: "false"). This helps avoid unnecessary updates for apps that are stopped.
@@ -66,6 +67,7 @@ docker run --name truenas-auto-update \
          -e API_KEY=your-api-key \
          -e API_USERNAME=admin \
          -e CRON_SCHEDULE="0 4 * * *" \
+         -e TZ="Europe/Zurich" \
          -e APPRISE_URLS="https://example.com/apprise,https://example.com/apprise2" \
          -e NOTIFY_ON_SUCCESS="true" \
          -e ONLY_UPDATE_STARTED_APPS="true" \
@@ -82,6 +84,7 @@ docker run --name truenas-auto-update \
          -e API_KEY=your-api-key \
          -e API_USERNAME=admin \
          -e CRON_SCHEDULE="0 4 * * *" \
+         -e TZ="Europe/Zurich" \
          -e AUTO_CLEANUP_IMAGES="true" \
          ghcr.io/marvinvr/truenas-auto-update
 ```
@@ -141,6 +144,7 @@ docker run --name truenas-auto-update \
          -e API_KEY=your-api-key \
          -e API_USERNAME=admin \
          -e CRON_SCHEDULE="0 4 * * *" \
+         -e TZ="Europe/Zurich" \
          -e AUTO_CLEANUP_IMAGES="true" \
          -e APPRISE_URLS="https://example.com/apprise" \
          ghcr.io/marvinvr/truenas-auto-update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
       # Optional: Cron schedule (comment out or leave empty for run-once mode)
       # - CRON_SCHEDULE=0 4 * * *
+      # - TZ=${TZ:-Europe/Zurich}
 
       # Optional: Notification settings
       - APPRISE_URLS=${APPRISE_URLS:-}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+if [ -n "$TZ" ]; then
+    if [ ! -f "/usr/share/zoneinfo/$TZ" ]; then
+        echo "Invalid timezone: $TZ"
+        exit 1
+    fi
+
+    ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
+    echo "$TZ" > /etc/timezone
+fi
+
 if [ -n "$CRON_SCHEDULE" ]; then
     # Set up environment variables for cron
     printenv | grep -v "no_proxy" >> /etc/environment
@@ -17,6 +27,7 @@ if [ -n "$CRON_SCHEDULE" ]; then
     service cron start
 
     echo "Cron job installed with schedule: $CRON_SCHEDULE"
+    echo "Cron timezone: ${TZ:-UTC}"
     echo "Watching logs..."
     tail -f /var/log/cron.log
 else


### PR DESCRIPTION
## Summary

- Add `tzdata` to the container image so timezone data is available at runtime
- Apply the optional `TZ` environment variable before cron starts
- Document `TZ` in the README and Docker Compose example

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional timezone configuration support via the `TZ` environment variable to control cron scheduling behavior.

* **Documentation**
  * Updated Docker usage examples and documentation to demonstrate timezone configuration.

* **Chores**
  * Enhanced Docker image and container initialization to support timezone setup and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marvinvr/truenas-auto-update/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->