### PR TITLE
Redeploy apps left on a stale image after a sibling pulled a shared tag

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -169,45 +169,45 @@ def wait_for_app_state(client, app_name, desired_state, timeout_seconds, reason)
     return last_state
 
 
-def ensure_running_after_upgrade(client, app_name):
-    """Restart an app if TrueNAS leaves it stopped after a successful upgrade."""
+def ensure_running_after_upgrade(client, app_name, operation="upgrade"):
+    """Restart an app if TrueNAS leaves it stopped after a successful operation."""
     final_state = wait_for_app_state(
         client,
         app_name,
         "RUNNING",
         APP_START_TIMEOUT_SECONDS,
-        "upgrade",
+        operation,
     )
 
     if normalize_state(final_state) == "RUNNING":
-        logger.info(f"{app_name} is running after upgrade")
+        logger.info(f"{app_name} is running after {operation}")
         return True
 
     if normalize_state(final_state) != "STOPPED":
         error_msg = (
-            f"Upgrade of {app_name} completed, but the app did not return to "
-            f"RUNNING within {APP_START_TIMEOUT_SECONDS} seconds "
+            f"{operation.capitalize()} of {app_name} completed, but the app did "
+            f"not return to RUNNING within {APP_START_TIMEOUT_SECONDS} seconds "
             f"(current state: {final_state})"
         )
         logger.error(error_msg)
         send_notification("App Not Running After Upgrade", error_msg)
         return False
 
-    logger.warning(f"{app_name} is stopped after upgrade; attempting to start it")
+    logger.warning(f"{app_name} is stopped after {operation}; attempting to start it")
     try:
         client.call("app.start", app_name, job=True)
     except CallTimeout:
-        error_msg = f"Start of {app_name} timed out after upgrade"
+        error_msg = f"Start of {app_name} timed out after {operation}"
         logger.error(error_msg)
         send_notification("App Start Timeout", error_msg)
         return False
     except ClientException as e:
-        error_msg = f"Failed to start {app_name} after upgrade: {e.error}"
+        error_msg = f"Failed to start {app_name} after {operation}: {e.error}"
         logger.error(error_msg)
         send_notification("App Start Failed After Upgrade", error_msg)
         return False
     except Exception as e:
-        error_msg = f"Failed to start {app_name} after upgrade: {str(e)}"
+        error_msg = f"Failed to start {app_name} after {operation}: {str(e)}"
         logger.error(error_msg)
         send_notification("App Start Failed After Upgrade", error_msg)
         return False
@@ -221,17 +221,58 @@ def ensure_running_after_upgrade(client, app_name):
     )
 
     if normalize_state(final_state) == "RUNNING":
-        logger.info(f"{app_name} started successfully after upgrade")
+        logger.info(f"{app_name} started successfully after {operation}")
         return True
 
     error_msg = (
-        f"Upgrade of {app_name} completed and a start was attempted, but the app "
-        f"did not reach RUNNING within {APP_START_TIMEOUT_SECONDS} seconds "
-        f"(current state: {final_state})"
+        f"{operation.capitalize()} of {app_name} completed and a start was "
+        f"attempted, but the app did not reach RUNNING within "
+        f"{APP_START_TIMEOUT_SECONDS} seconds (current state: {final_state})"
     )
     logger.error(error_msg)
     send_notification("App Start Failed After Upgrade", error_msg)
     return False
+
+
+def redeploy_stale_app(client, app_name, app_was_running):
+    """Redeploy an app that TrueNAS reported as having no upgrade available.
+
+    Custom apps (and ix-apps) are flagged ``upgrade_available`` whenever a newer
+    image exists for one of their docker tags. ``app.upgrade`` pulls that image,
+    redeploys the app and clears the shared image-update flag. When several apps
+    reference the same image tag, the first upgrade clears the flag for all of
+    them, so every sibling processed afterwards raises ``No upgrade available``
+    and is left running the old image even though the new one is already pulled
+    locally. A redeploy recreates the containers against the local image, which
+    is exactly what those siblings need.
+    """
+    logger.info(
+        f"{app_name} reports no upgrade available; a sibling app likely already "
+        f"pulled the shared image. Redeploying to pick up the local image."
+    )
+    try:
+        client.call("app.redeploy", app_name, job=True)
+
+        if app_was_running and not ensure_running_after_upgrade(
+            client, app_name, operation="redeploy"
+        ):
+            return
+
+        logger.info(f"Redeploy of {app_name} completed successfully")
+        if NOTIFY_ON_SUCCESS:
+            send_notification("App Redeployed", f"Redeployed {app_name} onto the latest local image")
+    except CallTimeout:
+        error_msg = f"Redeploy of {app_name} timed out"
+        logger.error(error_msg)
+        send_notification("Redeploy Timeout", error_msg)
+    except ClientException as e:
+        error_msg = f"Failed to redeploy {app_name}: {e.error}"
+        logger.error(error_msg)
+        send_notification("Redeploy Failed", error_msg)
+    except Exception as e:
+        error_msg = f"Failed to redeploy {app_name}: {str(e)}"
+        logger.error(error_msg)
+        send_notification("Redeploy Failed", error_msg)
 
 
 if not BASE_URL or not API_KEY:
@@ -308,9 +349,16 @@ try:
                 logger.error(error_msg)
                 send_notification("Upgrade Timeout", error_msg)
             except ClientException as e:
-                error_msg = f"Failed to upgrade {app_name}: {e.error}"
-                logger.error(error_msg)
-                send_notification("Upgrade Failed", error_msg)
+                # An app flagged for upgrade can report "No upgrade available" when a
+                # sibling app sharing the same image tag was upgraded first and cleared
+                # the shared image-update flag. The new image is already local, so the
+                # app just needs a redeploy to move onto it.
+                if "No upgrade available" in str(e.error):
+                    redeploy_stale_app(client, app_name, app_was_running)
+                else:
+                    error_msg = f"Failed to upgrade {app_name}: {e.error}"
+                    logger.error(error_msg)
+                    send_notification("Upgrade Failed", error_msg)
             except Exception as e:
                 error_msg = f"Failed to upgrade {app_name}: {str(e)}"
                 logger.error(error_msg)

--- a/app/main.py
+++ b/app/main.py
@@ -171,6 +171,7 @@ def wait_for_app_state(client, app_name, desired_state, timeout_seconds, reason)
 
 def ensure_running_after_upgrade(client, app_name, operation="upgrade"):
     """Restart an app if TrueNAS leaves it stopped after a successful operation."""
+    operation_title = operation.capitalize()
     final_state = wait_for_app_state(
         client,
         app_name,
@@ -185,12 +186,12 @@ def ensure_running_after_upgrade(client, app_name, operation="upgrade"):
 
     if normalize_state(final_state) != "STOPPED":
         error_msg = (
-            f"{operation.capitalize()} of {app_name} completed, but the app did "
+            f"{operation_title} of {app_name} completed, but the app did "
             f"not return to RUNNING within {APP_START_TIMEOUT_SECONDS} seconds "
             f"(current state: {final_state})"
         )
         logger.error(error_msg)
-        send_notification("App Not Running After Upgrade", error_msg)
+        send_notification(f"App Not Running After {operation_title}", error_msg)
         return False
 
     logger.warning(f"{app_name} is stopped after {operation}; attempting to start it")
@@ -204,12 +205,12 @@ def ensure_running_after_upgrade(client, app_name, operation="upgrade"):
     except ClientException as e:
         error_msg = f"Failed to start {app_name} after {operation}: {e.error}"
         logger.error(error_msg)
-        send_notification("App Start Failed After Upgrade", error_msg)
+        send_notification(f"App Start Failed After {operation_title}", error_msg)
         return False
     except Exception as e:
         error_msg = f"Failed to start {app_name} after {operation}: {str(e)}"
         logger.error(error_msg)
-        send_notification("App Start Failed After Upgrade", error_msg)
+        send_notification(f"App Start Failed After {operation_title}", error_msg)
         return False
 
     final_state = wait_for_app_state(
@@ -225,12 +226,12 @@ def ensure_running_after_upgrade(client, app_name, operation="upgrade"):
         return True
 
     error_msg = (
-        f"{operation.capitalize()} of {app_name} completed and a start was "
+        f"{operation_title} of {app_name} completed and a start was "
         f"attempted, but the app did not reach RUNNING within "
         f"{APP_START_TIMEOUT_SECONDS} seconds (current state: {final_state})"
     )
     logger.error(error_msg)
-    send_notification("App Start Failed After Upgrade", error_msg)
+    send_notification(f"App Start Failed After {operation_title}", error_msg)
     return False
 
 
@@ -242,13 +243,12 @@ def redeploy_stale_app(client, app_name, app_was_running):
     redeploys the app and clears the shared image-update flag. When several apps
     reference the same image tag, the first upgrade clears the flag for all of
     them, so every sibling processed afterwards raises ``No upgrade available``
-    and is left running the old image even though the new one is already pulled
-    locally. A redeploy recreates the containers against the local image, which
-    is exactly what those siblings need.
+    and is left running the old image. A redeploy stops the app, pulls latest
+    images and restarts it, which is exactly what those siblings need.
     """
     logger.info(
         f"{app_name} reports no upgrade available; a sibling app likely already "
-        f"pulled the shared image. Redeploying to pick up the local image."
+        f"handled the shared image update. Redeploying to pick up the latest image."
     )
     try:
         client.call("app.redeploy", app_name, job=True)
@@ -260,7 +260,7 @@ def redeploy_stale_app(client, app_name, app_was_running):
 
         logger.info(f"Redeploy of {app_name} completed successfully")
         if NOTIFY_ON_SUCCESS:
-            send_notification("App Redeployed", f"Redeployed {app_name} onto the latest local image")
+            send_notification("App Redeployed", f"Redeployed {app_name} onto the latest image")
     except CallTimeout:
         error_msg = f"Redeploy of {app_name} timed out"
         logger.error(error_msg)
@@ -318,6 +318,7 @@ try:
 
             app_state = app.get("state", "unknown")
             app_was_running = normalize_state(app_state) == "RUNNING"
+            app_had_image_update = bool(app.get("image_updates_available"))
 
             if EXCLUDE_APPS and app_name in EXCLUDE_APPS:
                 logger.info(f"Skipping upgrade for: {app_name} (APP in EXCLUDE_APPS)")
@@ -349,11 +350,11 @@ try:
                 logger.error(error_msg)
                 send_notification("Upgrade Timeout", error_msg)
             except ClientException as e:
-                # An app flagged for upgrade can report "No upgrade available" when a
-                # sibling app sharing the same image tag was upgraded first and cleared
-                # the shared image-update flag. The new image is already local, so the
-                # app just needs a redeploy to move onto it.
-                if "No upgrade available" in str(e.error):
+                # An app with image updates can report "No upgrade available" when a
+                # sibling sharing the same image tag was upgraded first and cleared the
+                # shared image-update flag. The app still needs a redeploy to move onto
+                # the updated image.
+                if app_had_image_update and "No upgrade available" in str(e.error):
                     redeploy_stale_app(client, app_name, app_was_running)
                 else:
                     error_msg = f"Failed to upgrade {app_name}: {e.error}"


### PR DESCRIPTION
Hi @marvinvr 👋

Ran into this one on my own setup and figured I'd send a fix your way.

## What happens

When two or more apps reference the same docker image tag and both are flagged
for upgrade, the first `app.upgrade` pulls the new image and clears the shared
image-update flag for that tag. Every sibling processed afterwards then raises
`[EFAULT] No upgrade available` and gets skipped — left running the old image
even though the new one is already pulled locally.

This PR catches that specific error and issues an `app.redeploy` instead, which
recreates the app's containers against the now-local image. Running state is
preserved through the existing `ensure_running_after_upgrade` helper (I
parameterised it with an operation label so the log/notification wording stays
correct for both "upgrade" and "redeploy").

## Testing

Verified on TrueNAS Scale 25.10 with two compose apps both using
`ghcr.io/home-operations/qbittorrent:5`, both flagged for upgrade
(qBittorrent 5.2.0 → 5.2.1):

- Before: the loop upgrades the first app to 5.2.1; the second reports "No
  upgrade available" and stays on 5.2.0.
- After: the first upgrades, the second is redeployed onto the already-pulled
  5.2.1 image, and both end up on 5.2.1 (running state restored).

Thanks again!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust recovery during upgrade/redeploy operations with operation-specific status and notification text
  * Handles apps that report spurious "no upgrade" by triggering a redeploy and verifying they return to RUNNING
  * Treats non-RUNNING terminal states as errors and attempts restart when STOPPED, reporting failures clearly
  * Improved notifications and logs for timeouts and deployment errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->