### PR TITLE
[codex] Add per-app update schedules

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests
+
+      - name: Compile Python files
+        run: python -m py_compile app/main.py app/generate_crontab.py
+
+      - name: Check shell syntax
+        run: bash -n docker-entrypoint.sh run-script.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,15 +9,16 @@ This is a simple Python application that automatically updates TrueNAS SCALE app
 ### Core Components
 
 - `app/main.py`: Main application that connects to TrueNAS API, checks for app updates, and performs upgrades
+- `app/generate_crontab.py`: Generates cron entries from the global schedule and per-app schedules
 - `docker-entrypoint.sh`: Entry script that handles both one-time runs and cron scheduling
 - `run-script.sh`: Wrapper script for cron execution
-- `crontab`: Template for cron schedule (uses environment variable substitution)
 
 ### Key Architecture Points
 
 - Uses TrueNAS JSON-RPC 2.0 API via WebSocket (`/api/current`) with the official `truenas-api-client` library
 - Implements notification system via Apprise library for multiple notification services
 - Supports both immediate execution and scheduled execution via cron
+- Scheduled mode generates cron entries at container startup. `APP_SCHEDULES` entries use TrueNAS app IDs for routing, while upgrade/start/redeploy API calls still use the app `name`.
 - Job waiting is handled automatically by the API client when using `job=True` parameter
 - Configurable SSL verification for TrueNAS API calls (disabled by default for self-signed certificates)
 
@@ -29,7 +30,9 @@ Required:
 
 Optional:
 - `API_USERNAME`: Username for API key authentication (default: root). Required for TrueNAS 25.04+ where API keys are user-linked.
-- `CRON_SCHEDULE`: Cron expression for scheduling (if not set, runs once)
+- `CRON_SCHEDULE`: Global cron expression for apps without custom schedules
+- `APP_SCHEDULES`: JSON object mapping TrueNAS app IDs to cron expressions. Apps with custom schedules are excluded from the global scheduled run.
+- `RUN_ON_START`: Run once immediately before starting cron when scheduled mode is enabled (default: false)
 - `APPRISE_URLS`: Comma-separated notification URLs
 - `NOTIFY_ON_SUCCESS`: Enable success notifications (default: false)
 - `SSL_VERIFY`: Enable SSL certificate verification (default: false)
@@ -40,6 +43,9 @@ Optional:
 ```bash
 # Install dependencies
 pip install -r requirements.txt
+
+# Run tests
+python3 -m unittest discover -s tests
 
 # Run the application locally (requires environment variables)
 cd app && python main.py
@@ -63,6 +69,15 @@ docker run --rm \
   -e API_KEY=your-api-key \
   -e API_USERNAME=admin \
   -e CRON_SCHEDULE="0 4 * * *" \
+  truenas-auto-update
+
+# Run container with per-app schedules
+docker run --rm \
+  -e BASE_URL=https://your-truenas-url \
+  -e API_KEY=your-api-key \
+  -e API_USERNAME=admin \
+  -e CRON_SCHEDULE="0 4 * * *" \
+  -e APP_SCHEDULES='{"plex":"0 3 * * *","immich":"30 4 * * 0"}' \
   truenas-auto-update
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     cron \
     tzdata \
-    gettext-base \
     ca-certificates \
     curl \
     gnupg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,4 @@ RUN chmod +x /app/docker-entrypoint.sh /app/run-script.sh
 # Create log file
 RUN touch /var/log/cron.log
 
-# Copy crontab file
-COPY crontab /etc/cron.d/app-cron
-
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With that configuration:
 
 If `APP_SCHEDULES` is set without `CRON_SCHEDULE`, only apps with custom schedules are checked. Apps without custom schedules are not scheduled.
 
-Cron uses normal cron semantics. If the container is stopped during a scheduled weekly or monthly run, that run is missed. Set `RUN_ON_START=true` if you want an update check whenever the container starts.
+Cron uses normal cron semantics. If the container is stopped during a scheduled weekly or monthly run, that run is missed. Set `RUN_ON_START=true` if you want an update check whenever the container starts. Note that the `RUN_ON_START` check ignores per-app schedules and checks every app (subject to `INCLUDE_APPS`/`EXCLUDE_APPS`), so custom-scheduled apps are also updated on startup.
 
 Apps that were running before an upgrade are checked afterward. If TrueNAS leaves one stopped, the updater waits up to 10 minutes,
 tries to start it once, and waits up to another 10 minutes before sending a failure notification.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `BASE_URL`: Your TrueNAS SCALE instance URL (e.g., `https://truenas.local`)
 - `API_KEY`: Your TrueNAS API key (see "Getting Started" for how to generate one)
 - `API_USERNAME` (_optional_): Username associated with the API key (default: `root`). **Required for TrueNAS 25.04+** where API keys are user-linked.
-- `CRON_SCHEDULE` (_optional_): Global cron schedule for when to check apps without custom schedules (e.g., `0 4 * * *` for daily at 4 AM). If neither `CRON_SCHEDULE` nor `APP_SCHEDULES` is set, the script will run once and then exit.
+- `CRON_SCHEDULE` (_optional_): Global cron schedule for when to check apps without custom schedules (e.g., `0 4 * * *` for daily at 4 AM). A 5-field expression or a cron nickname like `@daily` or `@hourly` may be used. If neither `CRON_SCHEDULE` nor `APP_SCHEDULES` is set, the script will run once and then exit.
 - `APP_SCHEDULES` (_optional_): JSON object mapping TrueNAS app IDs to custom cron schedules (e.g., `{"plex":"0 3 * * *","immich":"30 4 * * 0"}`). Apps listed here run on their custom schedules instead of the global `CRON_SCHEDULE`.
 - `RUN_ON_START` (_optional_): Set to "true" to run one update check immediately before starting cron when scheduled mode is enabled (default: "false").
 - `TZ` (_optional_): Timezone used by cron when evaluating `CRON_SCHEDULE` (e.g., `Europe/Zurich`). If not set, the container defaults to UTC.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `BASE_URL`: Your TrueNAS SCALE instance URL (e.g., `https://truenas.local`)
 - `API_KEY`: Your TrueNAS API key (see "Getting Started" for how to generate one)
 - `API_USERNAME` (_optional_): Username associated with the API key (default: `root`). **Required for TrueNAS 25.04+** where API keys are user-linked.
-- `CRON_SCHEDULE` (_optional_): Cron schedule for when to check for updates (e.g., `0 4 * * *` for daily at 4 AM). If not set, the script will run once and then exit.
+- `CRON_SCHEDULE` (_optional_): Global cron schedule for when to check apps without custom schedules (e.g., `0 4 * * *` for daily at 4 AM). If neither `CRON_SCHEDULE` nor `APP_SCHEDULES` is set, the script will run once and then exit.
+- `APP_SCHEDULES` (_optional_): JSON object mapping TrueNAS app IDs to custom cron schedules (e.g., `{"plex":"0 3 * * *","immich":"30 4 * * 0"}`). Apps listed here run on their custom schedules instead of the global `CRON_SCHEDULE`.
+- `RUN_ON_START` (_optional_): Set to "true" to run one update check immediately before starting cron when scheduled mode is enabled (default: "false").
 - `TZ` (_optional_): Timezone used by cron when evaluating `CRON_SCHEDULE` (e.g., `Europe/Zurich`). If not set, the container defaults to UTC.
 - `APPRISE_URLS` (_optional_): Apprise URLs to send notifications to (e.g., `https://example.com/apprise,https://example.com/apprise2`) More info on [Apprise](https://github.com/caronc/apprise)
 - `NOTIFY_ON_SUCCESS` (_optional_): Set to "true" to receive notifications when apps are successfully updated (default: "false")
@@ -18,6 +20,27 @@ Yes, I know what you're thinking - "You shouldn't auto-update your TrueNAS apps!
 - `AUTO_CLEANUP_IMAGES` (_optional_): Set to "true" to automatically clean up unused Docker images after all updates are complete (default: "false"). This runs `docker image prune -a -f` to remove all unused images and free up disk space. **Requires the Docker socket to be mounted** (see Docker Image Cleanup section below).
 
 NOTE: The `EXCLUDE_APPS` and `INCLUDE_APPS` variables are mutually exclusive. If both are set, the application will error out.
+
+### Per-App Schedules
+
+Use `APP_SCHEDULES` when some apps should update on their own cadence while the rest use the global `CRON_SCHEDULE`.
+
+```bash
+APP_SCHEDULES='{"plex":"0 3 * * *","immich":"30 4 * * 0"}'
+CRON_SCHEDULE="0 4 * * *"
+```
+
+With that configuration:
+
+- `plex` is checked daily at 3 AM
+- `immich` is checked Sundays at 4:30 AM
+- every other app is checked daily at 4 AM
+
+`APP_SCHEDULES` keys are TrueNAS app IDs. The existing `INCLUDE_APPS` and `EXCLUDE_APPS` filters still use app names and still apply to every scheduled run.
+
+If `APP_SCHEDULES` is set without `CRON_SCHEDULE`, only apps with custom schedules are checked. Apps without custom schedules are not scheduled.
+
+Cron uses normal cron semantics. If the container is stopped during a scheduled weekly or monthly run, that run is missed. Set `RUN_ON_START=true` if you want an update check whenever the container starts.
 
 Apps that were running before an upgrade are checked afterward. If TrueNAS leaves one stopped, the updater waits up to 10 minutes,
 tries to start it once, and waits up to another 10 minutes before sending a failure notification.
@@ -70,6 +93,8 @@ docker run --name truenas-auto-update \
          -e API_KEY=your-api-key \
          -e API_USERNAME=admin \
          -e CRON_SCHEDULE="0 4 * * *" \
+         -e APP_SCHEDULES='{"plex":"0 3 * * *","immich":"30 4 * * 0"}' \
+         -e RUN_ON_START="false" \
          -e TZ="Europe/Zurich" \
          -e APPRISE_URLS="https://example.com/apprise,https://example.com/apprise2" \
          -e NOTIFY_ON_SUCCESS="true" \

--- a/app/generate_crontab.py
+++ b/app/generate_crontab.py
@@ -16,6 +16,23 @@ _CRON_ATOM = r"(?:\d+|[A-Za-z]{3})"
 _CRON_ELEMENT = rf"(?:\*|{_CRON_ATOM}(?:-{_CRON_ATOM})?)(?:/\d+)?"
 CRON_FIELD_PATTERN = re.compile(rf"^{_CRON_ELEMENT}(?:,{_CRON_ELEMENT})*$")
 
+# Cron "nickname" schedules accepted in place of a 5-field expression. The cron
+# daemon in the container understands these, and the previous envsubst-based
+# crontab passed them through untouched, so we keep accepting them. Matched
+# case-insensitively and normalised to lowercase for the generated crontab.
+CRON_NICKNAMES = frozenset(
+    {
+        "@reboot",
+        "@yearly",
+        "@annually",
+        "@monthly",
+        "@weekly",
+        "@daily",
+        "@midnight",
+        "@hourly",
+    }
+)
+
 
 def parse_app_schedules(raw_value):
     """Parse the APP_SCHEDULES JSON map into a validated {app_id: schedule} dict."""
@@ -33,8 +50,7 @@ def parse_app_schedules(raw_value):
     parsed = OrderedDict()
     for app_id, schedule in schedules.items():
         validate_app_id(app_id)
-        validate_cron_schedule(schedule, f"APP_SCHEDULES[{app_id!r}]")
-        parsed[app_id] = schedule.strip()
+        parsed[app_id] = validate_cron_schedule(schedule, f"APP_SCHEDULES[{app_id!r}]")
 
     return parsed
 
@@ -52,17 +68,25 @@ def validate_app_id(app_id):
 
 
 def validate_cron_schedule(schedule, label):
-    """Validate a 5-field cron expression, checking each field's token syntax."""
+    """Validate a cron schedule and return its normalised form.
+
+    Accepts either a nickname like ``@daily`` or a 5-field cron expression,
+    checking each field's token syntax for the latter.
+    """
     if not isinstance(schedule, str):
         raise ValueError(f"{label} must be a string")
     if "\n" in schedule or "\r" in schedule:
         raise ValueError(f"{label} must not contain newlines")
-    fields = schedule.strip().split()
+    schedule = schedule.strip()
+    if schedule.lower() in CRON_NICKNAMES:
+        return schedule.lower()
+    fields = schedule.split()
     if len(fields) != 5:
-        raise ValueError(f"{label} must be a 5-field cron expression")
+        raise ValueError(f"{label} must be a 5-field cron expression or a nickname like @daily")
     for field in fields:
         if not CRON_FIELD_PATTERN.fullmatch(field):
             raise ValueError(f"{label} has an invalid cron field: {field!r}")
+    return schedule
 
 
 def group_schedules(app_schedules):
@@ -77,7 +101,7 @@ def build_crontab(cron_schedule, app_schedules):
     """Render cron lines for per-app schedules plus the global fallback schedule."""
     cron_schedule = cron_schedule.strip()
     if cron_schedule:
-        validate_cron_schedule(cron_schedule, "CRON_SCHEDULE")
+        cron_schedule = validate_cron_schedule(cron_schedule, "CRON_SCHEDULE")
 
     lines = []
     for schedule, app_ids in group_schedules(app_schedules).items():

--- a/app/generate_crontab.py
+++ b/app/generate_crontab.py
@@ -8,8 +8,17 @@ RUN_SCRIPT = "/app/run-script.sh"
 LOG_REDIRECT = ">> /var/log/cron.log 2>&1"
 APP_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
+# A single cron field element: "*", a number or 3-letter name (JAN, SUN), an
+# inclusive range of those, each optionally followed by a "/step". A field is a
+# comma-separated list of elements. This is intentionally permissive validation
+# to catch obvious garbage (e.g. "a b c d e") rather than a full cron parser.
+_CRON_ATOM = r"(?:\d+|[A-Za-z]{3})"
+_CRON_ELEMENT = rf"(?:\*|{_CRON_ATOM}(?:-{_CRON_ATOM})?)(?:/\d+)?"
+CRON_FIELD_PATTERN = re.compile(rf"^{_CRON_ELEMENT}(?:,{_CRON_ELEMENT})*$")
+
 
 def parse_app_schedules(raw_value):
+    """Parse the APP_SCHEDULES JSON map into a validated {app_id: schedule} dict."""
     if not raw_value.strip():
         return {}
 
@@ -31,6 +40,7 @@ def parse_app_schedules(raw_value):
 
 
 def validate_app_id(app_id):
+    """Reject app ids that are empty, padded, or contain shell-unsafe characters."""
     if not isinstance(app_id, str) or not app_id.strip():
         raise ValueError("APP_SCHEDULES app ids must be non-empty strings")
     if app_id != app_id.strip():
@@ -42,6 +52,7 @@ def validate_app_id(app_id):
 
 
 def validate_cron_schedule(schedule, label):
+    """Validate a 5-field cron expression, checking each field's token syntax."""
     if not isinstance(schedule, str):
         raise ValueError(f"{label} must be a string")
     if "\n" in schedule or "\r" in schedule:
@@ -49,9 +60,13 @@ def validate_cron_schedule(schedule, label):
     fields = schedule.strip().split()
     if len(fields) != 5:
         raise ValueError(f"{label} must be a 5-field cron expression")
+    for field in fields:
+        if not CRON_FIELD_PATTERN.fullmatch(field):
+            raise ValueError(f"{label} has an invalid cron field: {field!r}")
 
 
 def group_schedules(app_schedules):
+    """Group app ids by their shared cron schedule, preserving insertion order."""
     grouped = OrderedDict()
     for app_id, schedule in app_schedules.items():
         grouped.setdefault(schedule, []).append(app_id)
@@ -59,6 +74,7 @@ def group_schedules(app_schedules):
 
 
 def build_crontab(cron_schedule, app_schedules):
+    """Render cron lines for per-app schedules plus the global fallback schedule."""
     cron_schedule = cron_schedule.strip()
     if cron_schedule:
         validate_cron_schedule(cron_schedule, "CRON_SCHEDULE")
@@ -82,6 +98,7 @@ def build_crontab(cron_schedule, app_schedules):
 
 
 def main():
+    """Generate the crontab from environment config and print it to stdout."""
     try:
         app_schedules = parse_app_schedules(os.getenv("APP_SCHEDULES", ""))
         crontab = build_crontab(os.getenv("CRON_SCHEDULE", ""), app_schedules)

--- a/app/generate_crontab.py
+++ b/app/generate_crontab.py
@@ -1,0 +1,97 @@
+import json
+import os
+import re
+import sys
+from collections import OrderedDict
+
+RUN_SCRIPT = "/app/run-script.sh"
+LOG_REDIRECT = ">> /var/log/cron.log 2>&1"
+APP_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def parse_app_schedules(raw_value):
+    if not raw_value.strip():
+        return {}
+
+    try:
+        schedules = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"APP_SCHEDULES must be valid JSON: {exc}") from exc
+
+    if not isinstance(schedules, dict):
+        raise ValueError("APP_SCHEDULES must be a JSON object mapping app ids to cron schedules")
+
+    parsed = OrderedDict()
+    for app_id, schedule in schedules.items():
+        validate_app_id(app_id)
+        validate_cron_schedule(schedule, f"APP_SCHEDULES[{app_id!r}]")
+        parsed[app_id] = schedule.strip()
+
+    return parsed
+
+
+def validate_app_id(app_id):
+    if not isinstance(app_id, str) or not app_id.strip():
+        raise ValueError("APP_SCHEDULES app ids must be non-empty strings")
+    if app_id != app_id.strip():
+        raise ValueError(f"APP_SCHEDULES app id {app_id!r} must not have surrounding whitespace")
+    if not APP_ID_PATTERN.fullmatch(app_id):
+        raise ValueError(
+            f"APP_SCHEDULES app id {app_id!r} must only contain letters, numbers, dots, underscores, or hyphens"
+        )
+
+
+def validate_cron_schedule(schedule, label):
+    if not isinstance(schedule, str):
+        raise ValueError(f"{label} must be a string")
+    if "\n" in schedule or "\r" in schedule:
+        raise ValueError(f"{label} must not contain newlines")
+    fields = schedule.strip().split()
+    if len(fields) != 5:
+        raise ValueError(f"{label} must be a 5-field cron expression")
+
+
+def group_schedules(app_schedules):
+    grouped = OrderedDict()
+    for app_id, schedule in app_schedules.items():
+        grouped.setdefault(schedule, []).append(app_id)
+    return grouped
+
+
+def build_crontab(cron_schedule, app_schedules):
+    cron_schedule = cron_schedule.strip()
+    if cron_schedule:
+        validate_cron_schedule(cron_schedule, "CRON_SCHEDULE")
+
+    lines = []
+    for schedule, app_ids in group_schedules(app_schedules).items():
+        include_ids = ",".join(app_ids)
+        lines.append(
+            f"{schedule} SCHEDULE_INCLUDE_APP_IDS={include_ids} {RUN_SCRIPT} {LOG_REDIRECT}"
+        )
+
+    if cron_schedule:
+        custom_ids = ",".join(app_schedules.keys())
+        env_prefix = f"SCHEDULE_EXCLUDE_APP_IDS={custom_ids} " if custom_ids else ""
+        lines.append(f"{cron_schedule} {env_prefix}{RUN_SCRIPT} {LOG_REDIRECT}")
+
+    if lines:
+        lines.append("# An empty line is required at the end of this file for a valid cron file")
+
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def main():
+    try:
+        app_schedules = parse_app_schedules(os.getenv("APP_SCHEDULES", ""))
+        crontab = build_crontab(os.getenv("CRON_SCHEDULE", ""), app_schedules)
+    except ValueError as exc:
+        print(f"Invalid schedule configuration: {exc}", file=sys.stderr)
+        return 1
+
+    print(crontab, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/main.py
+++ b/app/main.py
@@ -318,6 +318,16 @@ try:
         apps = client.call("app.query")
         logger.info(f"Total apps found: {len(apps)}")
 
+        # Warn about configured app ids that do not match any app. APP_SCHEDULES
+        # keys are TrueNAS app ids, so a typo here silently skips the app forever.
+        known_app_ids = {app.get("id") for app in apps}
+        for configured_id in (*SCHEDULE_INCLUDE_APP_IDS, *SCHEDULE_EXCLUDE_APP_IDS):
+            if configured_id not in known_app_ids:
+                logger.warning(
+                    f"Scheduled app id '{configured_id}' does not match any TrueNAS app "
+                    f"(check APP_SCHEDULES; keys must be app ids, not names)"
+                )
+
         apps_with_upgrade = [app for app in apps if app.get("upgrade_available")]
 
         logger.info(f"Found {len(apps_with_upgrade)} apps with upgrade available")

--- a/app/main.py
+++ b/app/main.py
@@ -19,13 +19,26 @@ NOTIFY_ON_SUCCESS = os.getenv("NOTIFY_ON_SUCCESS", "false").lower() == "true"
 ONLY_UPDATE_STARTED_APPS = os.getenv("ONLY_UPDATE_STARTED_APPS", "false").lower() == "true"
 AUTO_CLEANUP_IMAGES = os.getenv("AUTO_CLEANUP_IMAGES", "false").lower() == "true"
 SSL_VERIFY = os.getenv("SSL_VERIFY", "false").lower() == "true"
-EXCLUDE_APPS = [app.strip() for app in os.getenv("EXCLUDE_APPS", "").strip().split(",") if app.strip()]
-INCLUDE_APPS = [app.strip() for app in os.getenv("INCLUDE_APPS", "").strip().split(",") if app.strip()]
 APP_START_TIMEOUT_SECONDS = 600
 APP_STATE_POLL_INTERVAL_SECONDS = 10
 
+
+def parse_csv_env(name):
+    """Parse a comma-separated environment variable into a clean list."""
+    return [item.strip() for item in os.getenv(name, "").strip().split(",") if item.strip()]
+
+
+EXCLUDE_APPS = parse_csv_env("EXCLUDE_APPS")
+INCLUDE_APPS = parse_csv_env("INCLUDE_APPS")
+SCHEDULE_EXCLUDE_APP_IDS = parse_csv_env("SCHEDULE_EXCLUDE_APP_IDS")
+SCHEDULE_INCLUDE_APP_IDS = parse_csv_env("SCHEDULE_INCLUDE_APP_IDS")
+
 if EXCLUDE_APPS and INCLUDE_APPS:
     logger.error("Cannot use both EXCLUDE_APPS and INCLUDE_APPS simultaneously")
+    exit(1)
+
+if SCHEDULE_EXCLUDE_APP_IDS and SCHEDULE_INCLUDE_APP_IDS:
+    logger.error("Cannot use both SCHEDULE_EXCLUDE_APP_IDS and SCHEDULE_INCLUDE_APP_IDS simultaneously")
     exit(1)
 
 # Initialize Apprise
@@ -315,6 +328,7 @@ try:
             if not app_name:
                 logger.warning(f"Skipping app with missing name: {app}")
                 continue
+            app_id = app.get("id")
 
             app_state = app.get("state", "unknown")
             app_was_running = normalize_state(app_state) == "RUNNING"
@@ -325,6 +339,12 @@ try:
                 continue
             if INCLUDE_APPS and app_name not in INCLUDE_APPS:
                 logger.info(f"Skipping upgrade for: {app_name} (APP not in INCLUDE_APPS)")
+                continue
+            if SCHEDULE_EXCLUDE_APP_IDS and app_id in SCHEDULE_EXCLUDE_APP_IDS:
+                logger.info(f"Skipping upgrade for: {app_name} (APP id in SCHEDULE_EXCLUDE_APP_IDS)")
+                continue
+            if SCHEDULE_INCLUDE_APP_IDS and app_id not in SCHEDULE_INCLUDE_APP_IDS:
+                logger.info(f"Skipping upgrade for: {app_name} (APP id not in SCHEDULE_INCLUDE_APP_IDS)")
                 continue
             if ONLY_UPDATE_STARTED_APPS and not app_was_running:
                 logger.info(f"Skipping upgrade for: {app_name} (APP not running, state: {app_state})")

--- a/crontab
+++ b/crontab
@@ -1,2 +1,0 @@
-${CRON_SCHEDULE} /app/run-script.sh >> /var/log/cron.log 2>&1
-# An empty line is required at the end of this file for a valid cron file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
 
       # Optional: Cron schedule (comment out or leave empty for run-once mode)
       # - CRON_SCHEDULE=0 4 * * *
+      # - APP_SCHEDULES={"plex":"0 3 * * *","immich":"30 4 * * 0"}
+      # - RUN_ON_START=false
       # - TZ=${TZ:-Europe/Zurich}
 
       # Optional: Notification settings

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,14 +11,15 @@ if [ -n "$TZ" ]; then
 fi
 
 if [ -n "$CRON_SCHEDULE" ] || [ -n "$APP_SCHEDULES" ]; then
-    # Set up environment variables for cron
+    # Set up environment variables for cron. Overwrite (not append) so repeated
+    # container restarts do not accumulate stale/duplicate entries.
     printenv \
         | grep -v "no_proxy" \
         | grep -v "^APP_SCHEDULES=" \
         | grep -v "^CRON_SCHEDULE=" \
         | grep -v "^SCHEDULE_INCLUDE_APP_IDS=" \
         | grep -v "^SCHEDULE_EXCLUDE_APP_IDS=" \
-        >> /etc/environment
+        > /etc/environment
 
     # Generate the crontab from the global and per-app schedules.
     if ! python /app/generate_crontab.py > /etc/cron.d/app-cron; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,19 @@ if [ -n "$TZ" ]; then
 fi
 
 if [ -n "$CRON_SCHEDULE" ] || [ -n "$APP_SCHEDULES" ]; then
+    # Generate the crontab from the global and per-app schedules.
+    if ! python /app/generate_crontab.py > /etc/cron.d/app-cron; then
+        exit 1
+    fi
+
+    if [ ! -s /etc/cron.d/app-cron ]; then
+        # CRON_SCHEDULE/APP_SCHEDULES were set but produced no schedule lines
+        # (e.g. APP_SCHEDULES='{}'). Fall back to a single run instead of
+        # starting cron with an empty crontab and idling forever.
+        echo "No cron schedules generated from CRON_SCHEDULE/APP_SCHEDULES; running once..."
+        exec python main.py
+    fi
+
     # Set up environment variables for cron. Overwrite (not append) so repeated
     # container restarts do not accumulate stale/duplicate entries.
     printenv \
@@ -21,10 +34,6 @@ if [ -n "$CRON_SCHEDULE" ] || [ -n "$APP_SCHEDULES" ]; then
         | grep -v "^SCHEDULE_EXCLUDE_APP_IDS=" \
         > /etc/environment
 
-    # Generate the crontab from the global and per-app schedules.
-    if ! python /app/generate_crontab.py > /etc/cron.d/app-cron; then
-        exit 1
-    fi
     chmod 0644 /etc/cron.d/app-cron
 
     # Install cron job

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,23 +10,38 @@ if [ -n "$TZ" ]; then
     echo "$TZ" > /etc/timezone
 fi
 
-if [ -n "$CRON_SCHEDULE" ]; then
+if [ -n "$CRON_SCHEDULE" ] || [ -n "$APP_SCHEDULES" ]; then
     # Set up environment variables for cron
-    printenv | grep -v "no_proxy" >> /etc/environment
+    printenv \
+        | grep -v "no_proxy" \
+        | grep -v "^APP_SCHEDULES=" \
+        | grep -v "^CRON_SCHEDULE=" \
+        | grep -v "^SCHEDULE_INCLUDE_APP_IDS=" \
+        | grep -v "^SCHEDULE_EXCLUDE_APP_IDS=" \
+        >> /etc/environment
 
-    # Process the crontab file with environment variables
-    envsubst < /etc/cron.d/app-cron > /etc/cron.d/app-cron.tmp
-    sed -i -e 's|\"||g' /etc/cron.d/app-cron
-    mv /etc/cron.d/app-cron.tmp /etc/cron.d/app-cron
+    # Generate the crontab from the global and per-app schedules.
+    if ! python /app/generate_crontab.py > /etc/cron.d/app-cron; then
+        exit 1
+    fi
     chmod 0644 /etc/cron.d/app-cron
 
     # Install cron job
     crontab /etc/cron.d/app-cron
 
+    if [ "$RUN_ON_START" = "true" ]; then
+        echo "RUN_ON_START=true, running script once before starting cron..."
+        python main.py
+    fi
+
     # Start cron service
     service cron start
 
-    echo "Cron job installed with schedule: $CRON_SCHEDULE"
+    echo "Cron job installed"
+    echo "Global cron schedule: ${CRON_SCHEDULE:-none}"
+    if [ -n "$APP_SCHEDULES" ]; then
+        echo "Per-app schedules installed from APP_SCHEDULES"
+    fi
     echo "Cron timezone: ${TZ:-UTC}"
     echo "Watching logs..."
     tail -f /var/log/cron.log

--- a/tests/main_harness.py
+++ b/tests/main_harness.py
@@ -97,12 +97,18 @@ class ConfigurableClient:
         cfg = ConfigurableClient.config
 
         if method == "auth.login_ex":
+            # Real SUCCESS responses also carry "user_info"; main.py only checks
+            # response_type, so we omit it. Non-SUCCESS values mirror real ones
+            # (AUTH_ERR, EXPIRED, OTP_REQUIRED, REDIRECT).
             return {"response_type": cfg.get("auth", "SUCCESS")}
         if method == "app.query":
             query_error = cfg.get("query_error")
             if query_error is not None:
                 raise query_error
             return list(cfg.get("apps", []))
+        # app.upgrade/app.redeploy return an AppEntry and app.start returns null
+        # in the real API; main.py ignores all three return values, so None is a
+        # faithful-enough stand-in. job=True is passed by main.py and accepted here.
         if method == "app.upgrade":
             self.upgraded_apps.append(args[0])
             self._act("upgrade", args[0], default_state=None)

--- a/tests/main_harness.py
+++ b/tests/main_harness.py
@@ -1,0 +1,194 @@
+"""Shared harness for exercising app/main.py end-to-end with a fake TrueNAS client.
+
+main.py runs its logic at module top-level (it is invoked as ``python main.py``),
+so tests drive it with ``runpy`` under ``run_name="__main__"`` while patching the
+``apprise`` and ``truenas_api_client`` imports with fakes. ``time.sleep`` is
+neutralised and ``time.monotonic`` is replaced with a deterministic clock that
+advances by more than the wait timeout each call, so every ``wait_for_app_state``
+loop polls exactly once and then times out instead of busy-spinning.
+"""
+
+import os
+import runpy
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_PATH = ROOT / "app" / "main.py"
+
+# Sentinel meaning "no configured behaviour for this app/method".
+_UNSET = object()
+
+
+class ClientException(Exception):
+    """Stand-in for truenas_api_client.exc.ClientException."""
+
+    def __init__(self, error):
+        super().__init__(error)
+        self.error = error
+
+
+class CallTimeout(Exception):
+    """Stand-in for truenas_api_client.exc.CallTimeout."""
+
+
+class FakeApprise:
+    """Records notifications so tests can assert on titles/bodies."""
+
+    def __init__(self):
+        self.notifications = []
+
+    def add(self, url):
+        pass
+
+    def notify(self, title, body):
+        self.notifications.append((title, body))
+
+
+class ConfigurableClient:
+    """Fake TrueNAS client driven by a per-run config dict on the class.
+
+    Config keys (all optional):
+      - ``apps``: list of app dicts (id/name/upgrade_available/state/...).
+        ``app.query`` returns the live dicts so state changes are observable.
+      - ``auth``: response_type returned by ``auth.login_ex`` (default SUCCESS).
+      - ``upgrade``/``start``/``redeploy``: {app_name: action}, where action is
+        either an Exception instance (raised) or a string (the app's new state).
+        Defaults: upgrade/redeploy leave state unchanged; start sets RUNNING.
+    """
+
+    instances = []
+    config = {}
+
+    def __init__(self, uri, verify_ssl=False):
+        self.uri = uri
+        self.verify_ssl = verify_ssl
+        self.calls = []
+        self.upgraded_apps = []
+        self.started_apps = []
+        self.redeployed_apps = []
+        ConfigurableClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def _set_state(self, name, state):
+        for app in ConfigurableClient.config.get("apps", []):
+            if app.get("name") == name:
+                app["state"] = state
+
+    def _act(self, method, name, default_state):
+        action = ConfigurableClient.config.get(method, {}).get(name, _UNSET)
+        if isinstance(action, Exception):
+            raise action
+        new_state = action if isinstance(action, str) else default_state
+        if new_state is not None:
+            self._set_state(name, new_state)
+
+    def call(self, method, *args, **kwargs):
+        self.calls.append((method, args))
+        cfg = ConfigurableClient.config
+
+        if method == "auth.login_ex":
+            return {"response_type": cfg.get("auth", "SUCCESS")}
+        if method == "app.query":
+            query_error = cfg.get("query_error")
+            if query_error is not None:
+                raise query_error
+            return list(cfg.get("apps", []))
+        if method == "app.upgrade":
+            self.upgraded_apps.append(args[0])
+            self._act("upgrade", args[0], default_state=None)
+            return None
+        if method == "app.start":
+            self.started_apps.append(args[0])
+            self._act("start", args[0], default_state="RUNNING")
+            return None
+        if method == "app.redeploy":
+            self.redeployed_apps.append(args[0])
+            self._act("redeploy", args[0], default_state=None)
+            return None
+        raise AssertionError(f"Unexpected API call: {method}")
+
+
+class Result:
+    """Bundles the outcome of a harness run for assertions."""
+
+    def __init__(self, client, namespace):
+        self.client = client
+        self.namespace = namespace
+
+    @property
+    def notifications(self):
+        apobj = self.namespace.get("apobj") if self.namespace else None
+        return list(getattr(apobj, "notifications", []))
+
+    @property
+    def notification_titles(self):
+        return [title for title, _ in self.notifications]
+
+
+def run_main(config=None, extra_env=None):
+    """Run app/main.py against a ConfigurableClient and return a Result.
+
+    ``config`` is stored on ConfigurableClient for the duration of the run.
+    ``APPRISE_URLS`` defaults to a dummy value so notifications are recorded;
+    pass ``{"APPRISE_URLS": ""}`` to disable.
+    """
+    ConfigurableClient.instances = []
+    ConfigurableClient.config = config or {"apps": []}
+
+    apprise_module = types.SimpleNamespace(Apprise=FakeApprise)
+    truenas_module = types.SimpleNamespace(Client=ConfigurableClient)
+    exc_module = types.SimpleNamespace(
+        ClientException=ClientException,
+        CallTimeout=CallTimeout,
+    )
+
+    env = {
+        "BASE_URL": "https://truenas.local",
+        "API_KEY": "test-api-key",
+        "APPRISE_URLS": "json://example.com",
+    }
+    env.update(extra_env or {})
+
+    counter = {"t": 0}
+
+    def fake_monotonic():
+        counter["t"] += 400
+        return counter["t"]
+
+    namespace = {}
+    with patch.dict(os.environ, env, clear=True), patch.dict(
+        sys.modules,
+        {
+            "apprise": apprise_module,
+            "truenas_api_client": truenas_module,
+            "truenas_api_client.exc": exc_module,
+        },
+    ), patch.object(time, "sleep", lambda seconds: None), patch.object(
+        time, "monotonic", fake_monotonic
+    ):
+        namespace = runpy.run_path(str(MAIN_PATH), run_name="__main__")
+
+    client = ConfigurableClient.instances[-1] if ConfigurableClient.instances else None
+    return Result(client, namespace)
+
+
+def make_app(name, *, app_id=None, upgrade_available=True, state="RUNNING",
+             image_updates_available=False):
+    """Build an app dict with sensible defaults for tests."""
+    return {
+        "id": app_id or f"{name}-id",
+        "name": name,
+        "upgrade_available": upgrade_available,
+        "state": state,
+        "image_updates_available": image_updates_available,
+    }

--- a/tests/test_generate_crontab.py
+++ b/tests/test_generate_crontab.py
@@ -1,0 +1,78 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "generate_crontab",
+    ROOT / "app" / "generate_crontab.py",
+)
+generate_crontab = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_crontab)
+
+
+class GenerateCrontabTest(unittest.TestCase):
+    def test_builds_global_schedule_without_per_app_schedules(self):
+        crontab = generate_crontab.build_crontab("0 4 * * *", {})
+
+        self.assertIn("0 4 * * * /app/run-script.sh >> /var/log/cron.log 2>&1", crontab)
+        self.assertNotIn("SCHEDULE_EXCLUDE_APP_IDS", crontab)
+
+    def test_builds_per_app_schedules_and_global_fallback(self):
+        schedules = generate_crontab.parse_app_schedules(
+            '{"plex":"0 3 * * *","immich":"30 4 * * 0"}'
+        )
+
+        crontab = generate_crontab.build_crontab("0 4 * * *", schedules)
+
+        self.assertIn(
+            "0 3 * * * SCHEDULE_INCLUDE_APP_IDS=plex /app/run-script.sh >> /var/log/cron.log 2>&1",
+            crontab,
+        )
+        self.assertIn(
+            "30 4 * * 0 SCHEDULE_INCLUDE_APP_IDS=immich /app/run-script.sh >> /var/log/cron.log 2>&1",
+            crontab,
+        )
+        self.assertIn(
+            "0 4 * * * SCHEDULE_EXCLUDE_APP_IDS=plex,immich /app/run-script.sh >> /var/log/cron.log 2>&1",
+            crontab,
+        )
+
+    def test_groups_apps_that_share_the_same_schedule(self):
+        schedules = generate_crontab.parse_app_schedules(
+            '{"plex":"0 3 * * *","sonarr":"0 3 * * *"}'
+        )
+
+        crontab = generate_crontab.build_crontab("", schedules)
+
+        self.assertIn(
+            "0 3 * * * SCHEDULE_INCLUDE_APP_IDS=plex,sonarr /app/run-script.sh >> /var/log/cron.log 2>&1",
+            crontab,
+        )
+
+    def test_rejects_invalid_json(self):
+        with self.assertRaisesRegex(ValueError, "valid JSON"):
+            generate_crontab.parse_app_schedules("{not-json")
+
+    def test_rejects_non_object_json(self):
+        with self.assertRaisesRegex(ValueError, "JSON object"):
+            generate_crontab.parse_app_schedules('["plex"]')
+
+    def test_rejects_invalid_cron_schedule(self):
+        with self.assertRaisesRegex(ValueError, "5-field cron"):
+            generate_crontab.parse_app_schedules('{"plex":"0 3 * *"}')
+
+    def test_rejects_app_ids_with_commas(self):
+        with self.assertRaisesRegex(ValueError, "only contain"):
+            generate_crontab.parse_app_schedules('{"plex,other":"0 3 * * *"}')
+
+    def test_rejects_app_ids_with_shell_metacharacters(self):
+        with self.assertRaisesRegex(ValueError, "only contain"):
+            generate_crontab.parse_app_schedules(
+                '{"plex;touch${IFS}/tmp/pwned":"0 3 * * *"}'
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_crontab.py
+++ b/tests/test_generate_crontab.py
@@ -63,6 +63,17 @@ class GenerateCrontabTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "5-field cron"):
             generate_crontab.parse_app_schedules('{"plex":"0 3 * *"}')
 
+    def test_rejects_five_fields_with_invalid_tokens(self):
+        with self.assertRaisesRegex(ValueError, "invalid cron field"):
+            generate_crontab.parse_app_schedules('{"plex":"a b c d e"}')
+
+    def test_accepts_cron_ranges_steps_lists_and_names(self):
+        schedules = generate_crontab.parse_app_schedules(
+            '{"plex":"*/15 0-6 1,15 * MON-FRI"}'
+        )
+
+        self.assertEqual(schedules["plex"], "*/15 0-6 1,15 * MON-FRI")
+
     def test_rejects_app_ids_with_commas(self):
         with self.assertRaisesRegex(ValueError, "only contain"):
             generate_crontab.parse_app_schedules('{"plex,other":"0 3 * * *"}')

--- a/tests/test_generate_crontab.py
+++ b/tests/test_generate_crontab.py
@@ -74,6 +74,27 @@ class GenerateCrontabTest(unittest.TestCase):
 
         self.assertEqual(schedules["plex"], "*/15 0-6 1,15 * MON-FRI")
 
+    def test_accepts_cron_nickname_schedule(self):
+        schedules = generate_crontab.parse_app_schedules('{"plex":"@daily"}')
+
+        self.assertEqual(schedules["plex"], "@daily")
+
+    def test_normalises_nickname_case(self):
+        schedules = generate_crontab.parse_app_schedules('{"plex":" @Daily "}')
+
+        self.assertEqual(schedules["plex"], "@daily")
+
+    def test_builds_nickname_global_schedule(self):
+        crontab = generate_crontab.build_crontab("@hourly", {})
+
+        self.assertIn(
+            "@hourly /app/run-script.sh >> /var/log/cron.log 2>&1", crontab
+        )
+
+    def test_rejects_unknown_nickname(self):
+        with self.assertRaisesRegex(ValueError, "nickname"):
+            generate_crontab.parse_app_schedules('{"plex":"@yearlyish"}')
+
     def test_rejects_app_ids_with_commas(self):
         with self.assertRaisesRegex(ValueError, "only contain"):
             generate_crontab.parse_app_schedules('{"plex,other":"0 3 * * *"}')

--- a/tests/test_main_existing.py
+++ b/tests/test_main_existing.py
@@ -1,0 +1,135 @@
+import os
+import runpy
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN_PATH = ROOT / "app" / "main.py"
+
+
+class FakeApprise:
+    def add(self, url):
+        pass
+
+    def notify(self, title, body):
+        pass
+
+
+class FakeClientException(Exception):
+    def __init__(self, error):
+        super().__init__(error)
+        self.error = error
+
+
+class FakeCallTimeout(Exception):
+    pass
+
+
+class FakeClient:
+    instances = []
+
+    def __init__(self, uri, verify_ssl=False):
+        self.uri = uri
+        self.verify_ssl = verify_ssl
+        self.upgraded_apps = []
+        FakeClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def call(self, method, *args, **kwargs):
+        if method == "auth.login_ex":
+            return {"response_type": "SUCCESS"}
+        if method == "app.query":
+            return [
+                {
+                    "id": "app-one-id",
+                    "name": "app-one",
+                    "upgrade_available": True,
+                    "state": "STOPPED",
+                },
+                {
+                    "id": "app-two-id",
+                    "name": "app-two",
+                    "upgrade_available": True,
+                    "state": "STOPPED",
+                },
+                {
+                    "id": "current-id",
+                    "name": "current-app",
+                    "upgrade_available": False,
+                    "state": "STOPPED",
+                },
+            ]
+        if method == "app.upgrade":
+            self.upgraded_apps.append(args[0])
+            return None
+        raise AssertionError(f"Unexpected API call: {method}")
+
+
+def run_main(extra_env=None):
+    FakeClient.instances = []
+    apprise_module = types.SimpleNamespace(Apprise=FakeApprise)
+    truenas_module = types.SimpleNamespace(Client=FakeClient)
+    exc_module = types.SimpleNamespace(
+        ClientException=FakeClientException,
+        CallTimeout=FakeCallTimeout,
+    )
+    env = {
+        "BASE_URL": "https://truenas.local",
+        "API_KEY": "test-api-key",
+    }
+    env.update(extra_env or {})
+
+    original_sleep = time.sleep
+    time.sleep = lambda seconds: None
+    try:
+        with patch.dict(os.environ, env, clear=True), patch.dict(
+            sys.modules,
+            {
+                "apprise": apprise_module,
+                "truenas_api_client": truenas_module,
+                "truenas_api_client.exc": exc_module,
+            },
+        ):
+            runpy.run_path(str(MAIN_PATH), run_name="__main__")
+    finally:
+        time.sleep = original_sleep
+
+    return FakeClient.instances[-1]
+
+
+class ExistingMainBehaviorTest(unittest.TestCase):
+    def test_exclude_apps_skips_matching_app_names(self):
+        client = run_main({"EXCLUDE_APPS": "app-one"})
+
+        self.assertEqual(client.upgraded_apps, ["app-two"])
+
+    def test_include_apps_limits_updates_to_matching_app_names(self):
+        client = run_main({"INCLUDE_APPS": "app-two"})
+
+        self.assertEqual(client.upgraded_apps, ["app-two"])
+
+    def test_only_update_started_apps_skips_stopped_apps(self):
+        client = run_main({"ONLY_UPDATE_STARTED_APPS": "true"})
+
+        self.assertEqual(client.upgraded_apps, [])
+
+    def test_include_and_exclude_apps_cannot_be_combined(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({"INCLUDE_APPS": "app-one", "EXCLUDE_APPS": "app-two"})
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(FakeClient.instances, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_lifecycle.py
+++ b/tests/test_main_lifecycle.py
@@ -1,0 +1,301 @@
+import subprocess
+import types
+import unittest
+from unittest.mock import patch
+
+from main_harness import (
+    CallTimeout,
+    ClientException,
+    ConfigurableClient,
+    make_app,
+    run_main,
+)
+
+
+class PureHelperTest(unittest.TestCase):
+    """Unit tests for the side-effect-free helpers in main.py."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ns = run_main({"apps": []}).namespace
+
+    def test_build_websocket_uri_converts_https_to_wss(self):
+        build = self.ns["build_websocket_uri"]
+        self.assertEqual(
+            build("https://truenas.local"), "wss://truenas.local/api/current"
+        )
+
+    def test_build_websocket_uri_preserves_host_and_port(self):
+        build = self.ns["build_websocket_uri"]
+        self.assertEqual(
+            build("http://10.0.0.5:8080"), "wss://10.0.0.5:8080/api/current"
+        )
+
+    def test_normalize_state_uppercases(self):
+        normalize = self.ns["normalize_state"]
+        self.assertEqual(normalize("running"), "RUNNING")
+
+    def test_normalize_state_handles_none(self):
+        normalize = self.ns["normalize_state"]
+        self.assertEqual(normalize(None), "UNKNOWN")
+
+    def test_parse_csv_env_strips_and_drops_blanks(self):
+        parse = self.ns["parse_csv_env"]
+        with patch.dict("os.environ", {"X": " a , ,b ,"}, clear=False):
+            self.assertEqual(parse("X"), ["a", "b"])
+
+
+class UpgradeSuccessTest(unittest.TestCase):
+    def test_running_app_stays_running_and_notifies_on_success(self):
+        result = run_main(
+            {"apps": [make_app("plex", state="RUNNING")]},
+            {"NOTIFY_ON_SUCCESS": "true"},
+        )
+
+        self.assertEqual(result.client.upgraded_apps, ["plex"])
+        self.assertEqual(result.client.started_apps, [])
+        self.assertIn("App Updated", result.notification_titles)
+
+    def test_success_does_not_notify_when_notify_on_success_disabled(self):
+        result = run_main({"apps": [make_app("plex", state="RUNNING")]})
+
+        self.assertEqual(result.client.upgraded_apps, ["plex"])
+        self.assertEqual(result.notifications, [])
+
+    def test_stopped_app_is_not_started_after_upgrade(self):
+        # app_was_running is False, so the restart path is skipped entirely.
+        result = run_main({"apps": [make_app("plex", state="STOPPED")]})
+
+        self.assertEqual(result.client.upgraded_apps, ["plex"])
+        self.assertEqual(result.client.started_apps, [])
+        self.assertEqual(result.notifications, [])
+
+
+class EnsureRunningAfterUpgradeTest(unittest.TestCase):
+    def test_app_stopped_after_upgrade_is_started(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": "STOPPED"},  # upgrade leaves it stopped
+                "start": {"plex": "RUNNING"},  # start brings it back
+            }
+        )
+
+        self.assertEqual(result.client.started_apps, ["plex"])
+        self.assertEqual(result.notifications, [])
+
+    def test_start_failure_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": "STOPPED"},
+                "start": {"plex": ClientException("boom")},
+            }
+        )
+
+        self.assertEqual(result.client.started_apps, ["plex"])
+        self.assertIn("App Start Failed After Upgrade", result.notification_titles)
+
+    def test_start_timeout_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": "STOPPED"},
+                "start": {"plex": CallTimeout()},
+            }
+        )
+
+        self.assertIn("App Start Timeout", result.notification_titles)
+
+    def test_app_that_stays_stopped_after_start_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": "STOPPED"},
+                "start": {"plex": "STOPPED"},  # start does not bring it back
+            }
+        )
+
+        self.assertEqual(result.client.started_apps, ["plex"])
+        self.assertIn("App Start Failed After Upgrade", result.notification_titles)
+
+    def test_app_in_unexpected_state_after_upgrade_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": "CRASHED"},  # neither RUNNING nor STOPPED
+            }
+        )
+
+        # No start is attempted for a non-STOPPED state.
+        self.assertEqual(result.client.started_apps, [])
+        self.assertIn("App Not Running After Upgrade", result.notification_titles)
+
+
+class UpgradeErrorHandlingTest(unittest.TestCase):
+    def test_upgrade_timeout_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": CallTimeout()},
+            }
+        )
+
+        self.assertIn("Upgrade Timeout", result.notification_titles)
+
+    def test_generic_upgrade_failure_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": ClientException("nope")},
+            }
+        )
+
+        self.assertIn("Upgrade Failed", result.notification_titles)
+
+    def test_unexpected_exception_during_upgrade_is_reported(self):
+        result = run_main(
+            {
+                "apps": [make_app("plex", state="RUNNING")],
+                "upgrade": {"plex": RuntimeError("kaboom")},
+            }
+        )
+
+        self.assertIn("Upgrade Failed", result.notification_titles)
+
+
+class RedeployStaleAppTest(unittest.TestCase):
+    def _stale_config(self, **overrides):
+        config = {
+            "apps": [
+                make_app("plex", state="RUNNING", image_updates_available=True)
+            ],
+            "upgrade": {"plex": ClientException("No upgrade available")},
+        }
+        config.update(overrides)
+        return config
+
+    def test_no_upgrade_available_with_image_update_triggers_redeploy(self):
+        result = run_main(self._stale_config(), {"NOTIFY_ON_SUCCESS": "true"})
+
+        self.assertEqual(result.client.redeployed_apps, ["plex"])
+        self.assertIn("App Redeployed", result.notification_titles)
+
+    def test_no_upgrade_available_without_image_update_is_a_failure(self):
+        result = run_main(
+            {
+                "apps": [
+                    make_app("plex", state="RUNNING", image_updates_available=False)
+                ],
+                "upgrade": {"plex": ClientException("No upgrade available")},
+            }
+        )
+
+        self.assertEqual(result.client.redeployed_apps, [])
+        self.assertIn("Upgrade Failed", result.notification_titles)
+
+    def test_redeploy_timeout_is_reported(self):
+        result = run_main(self._stale_config(redeploy={"plex": CallTimeout()}))
+
+        self.assertIn("Redeploy Timeout", result.notification_titles)
+
+    def test_redeploy_failure_is_reported(self):
+        result = run_main(
+            self._stale_config(redeploy={"plex": ClientException("denied")})
+        )
+
+        self.assertIn("Redeploy Failed", result.notification_titles)
+
+    def test_stopped_stale_app_is_redeployed_without_restart(self):
+        result = run_main(
+            self._stale_config(
+                apps=[
+                    make_app("plex", state="STOPPED", image_updates_available=True)
+                ]
+            )
+        )
+
+        self.assertEqual(result.client.redeployed_apps, ["plex"])
+        self.assertEqual(result.client.started_apps, [])
+
+
+class CleanupDockerImagesTest(unittest.TestCase):
+    def _run_with_docker(self, fake_run, env):
+        with patch.object(subprocess, "run", fake_run):
+            return run_main({"apps": []}, env)
+
+    def test_disabled_by_default_runs_no_docker_commands(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        self._run_with_docker(fake_run, {})
+        self.assertEqual(calls, [])
+
+    def test_successful_cleanup_emits_no_warning(self):
+        def fake_run(cmd, **kwargs):
+            return types.SimpleNamespace(returncode=0, stdout="done", stderr="")
+
+        result = self._run_with_docker(fake_run, {"AUTO_CLEANUP_IMAGES": "true"})
+        self.assertEqual(
+            [t for t in result.notification_titles if "Docker" in t], []
+        )
+
+    def test_inaccessible_daemon_warns(self):
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["docker", "info"]:
+                return types.SimpleNamespace(returncode=1, stdout="", stderr="no")
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        result = self._run_with_docker(fake_run, {"AUTO_CLEANUP_IMAGES": "true"})
+        self.assertIn("Docker Cleanup Warning", result.notification_titles)
+
+    def test_missing_docker_cli_warns(self):
+        def fake_run(cmd, **kwargs):
+            raise FileNotFoundError("docker")
+
+        result = self._run_with_docker(fake_run, {"AUTO_CLEANUP_IMAGES": "true"})
+        self.assertIn("Docker Cleanup Warning", result.notification_titles)
+
+    def test_prune_failure_notifies(self):
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["docker", "info"]:
+                return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="prune failed")
+
+        result = self._run_with_docker(fake_run, {"AUTO_CLEANUP_IMAGES": "true"})
+        self.assertIn("Docker Cleanup Failed", result.notification_titles)
+
+
+class ConfigAndConnectionErrorTest(unittest.TestCase):
+    def test_missing_base_url_exits_without_connecting(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({"apps": []}, {"BASE_URL": ""})
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(ConfigurableClient.instances, [])
+
+    def test_missing_api_key_exits_without_connecting(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({"apps": []}, {"API_KEY": ""})
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(ConfigurableClient.instances, [])
+
+    def test_auth_failure_exits(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({"apps": [], "auth": "FAILED"})
+
+        self.assertEqual(raised.exception.code, 1)
+
+    def test_api_error_during_query_exits(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({"apps": [], "query_error": ClientException("api down")})
+
+        self.assertEqual(raised.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_lifecycle.py
+++ b/tests/test_main_lifecycle.py
@@ -62,9 +62,10 @@ class UpgradeSuccessTest(unittest.TestCase):
         self.assertEqual(result.client.upgraded_apps, ["plex"])
         self.assertEqual(result.notifications, [])
 
-    def test_stopped_app_is_not_started_after_upgrade(self):
-        # app_was_running is False, so the restart path is skipped entirely.
-        result = run_main({"apps": [make_app("plex", state="STOPPED")]})
+    def test_non_running_app_is_not_restarted_after_upgrade(self):
+        # app_was_running is False (DEPLOYING is neither RUNNING nor STOPPED, so
+        # the real API still permits the upgrade), so the restart path is skipped.
+        result = run_main({"apps": [make_app("plex", state="DEPLOYING")]})
 
         self.assertEqual(result.client.upgraded_apps, ["plex"])
         self.assertEqual(result.client.started_apps, [])
@@ -163,6 +164,27 @@ class UpgradeErrorHandlingTest(unittest.TestCase):
 
         self.assertIn("Upgrade Failed", result.notification_titles)
 
+    def test_stopped_app_upgrade_rejected_by_server_is_reported(self):
+        # The real TrueNAS API rejects upgrading a STOPPED app
+        # (CallError: "In order to upgrade an app, it must not be in stopped
+        # state"). main.py surfaces it as a generic upgrade failure, and the
+        # message must NOT match the redeploy trigger.
+        result = run_main(
+            {
+                "apps": [
+                    make_app("plex", state="STOPPED", image_updates_available=True)
+                ],
+                "upgrade": {
+                    "plex": ClientException(
+                        "In order to upgrade an app, it must not be in stopped state"
+                    )
+                },
+            }
+        )
+
+        self.assertEqual(result.client.redeployed_apps, [])
+        self.assertIn("Upgrade Failed", result.notification_titles)
+
 
 class RedeployStaleAppTest(unittest.TestCase):
     def _stale_config(self, **overrides):
@@ -170,7 +192,10 @@ class RedeployStaleAppTest(unittest.TestCase):
             "apps": [
                 make_app("plex", state="RUNNING", image_updates_available=True)
             ],
-            "upgrade": {"plex": ClientException("No upgrade available")},
+            # Real middleware message: CallError(f'No upgrade available for {app_name!r}').
+            # This is what a sibling sharing an image tag sees after the first
+            # app's upgrade clears the shared image-update flag.
+            "upgrade": {"plex": ClientException("No upgrade available for 'plex'")},
         }
         config.update(overrides)
         return config
@@ -187,7 +212,7 @@ class RedeployStaleAppTest(unittest.TestCase):
                 "apps": [
                     make_app("plex", state="RUNNING", image_updates_available=False)
                 ],
-                "upgrade": {"plex": ClientException("No upgrade available")},
+                "upgrade": {"plex": ClientException("No upgrade available for 'plex'")},
             }
         )
 
@@ -285,8 +310,10 @@ class ConfigAndConnectionErrorTest(unittest.TestCase):
         self.assertEqual(ConfigurableClient.instances, [])
 
     def test_auth_failure_exits(self):
+        # AUTH_ERR is a real auth.login_ex response_type; any non-SUCCESS value
+        # is treated as a failure by main.py.
         with self.assertRaises(SystemExit) as raised:
-            run_main({"apps": [], "auth": "FAILED"})
+            run_main({"apps": [], "auth": "AUTH_ERR"})
 
         self.assertEqual(raised.exception.code, 1)
 

--- a/tests/test_main_schedule_filters.py
+++ b/tests/test_main_schedule_filters.py
@@ -37,6 +37,25 @@ class ScheduleFilterBehaviorTest(unittest.TestCase):
         self.assertEqual(raised.exception.code, 1)
         self.assertEqual(FakeClient.instances, [])
 
+    def test_warns_when_scheduled_app_id_matches_no_app(self):
+        with self.assertLogs("__main__", level="WARNING") as captured:
+            run_main({"SCHEDULE_INCLUDE_APP_IDS": "does-not-exist"})
+
+        self.assertTrue(
+            any("does-not-exist" in message for message in captured.output)
+        )
+
+    def test_does_not_warn_when_scheduled_app_id_exists(self):
+        with self.assertLogs("__main__", level="WARNING") as captured:
+            run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
+            import logging
+
+            logging.getLogger("__main__").warning("sentinel")
+
+        self.assertFalse(
+            any("does not match any TrueNAS app" in message for message in captured.output)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main_schedule_filters.py
+++ b/tests/test_main_schedule_filters.py
@@ -1,0 +1,42 @@
+from test_main_existing import FakeClient, run_main
+
+import unittest
+
+
+class ScheduleFilterBehaviorTest(unittest.TestCase):
+    def test_schedule_include_app_ids_limits_updates_by_app_id(self):
+        client = run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
+
+        self.assertEqual(client.upgraded_apps, ["app-two"])
+
+    def test_schedule_exclude_app_ids_skips_matching_app_ids(self):
+        client = run_main({"SCHEDULE_EXCLUDE_APP_IDS": "app-one-id"})
+
+        self.assertEqual(client.upgraded_apps, ["app-two"])
+
+    def test_schedule_filters_use_id_not_name(self):
+        client = run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two"})
+
+        self.assertEqual(client.upgraded_apps, [])
+
+    def test_user_exclude_apps_still_applies_with_schedule_include_ids(self):
+        client = run_main({
+            "EXCLUDE_APPS": "app-two",
+            "SCHEDULE_INCLUDE_APP_IDS": "app-two-id",
+        })
+
+        self.assertEqual(client.upgraded_apps, [])
+
+    def test_schedule_include_and_exclude_ids_cannot_be_combined(self):
+        with self.assertRaises(SystemExit) as raised:
+            run_main({
+                "SCHEDULE_INCLUDE_APP_IDS": "app-one-id",
+                "SCHEDULE_EXCLUDE_APP_IDS": "app-two-id",
+            })
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertEqual(FakeClient.instances, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_main_schedule_filters.py
+++ b/tests/test_main_schedule_filters.py
@@ -1,60 +1,70 @@
-from test_main_existing import FakeClient, run_main
-
 import unittest
+
+from main_harness import ConfigurableClient, make_app, run_main
+
+
+def _apps():
+    # Two running apps with distinct ids and names, so tests can verify that
+    # schedule filters route by id while upgrade calls use name. RUNNING matches
+    # what the real API requires for an upgrade (it rejects STOPPED apps).
+    return [
+        make_app("app-one", app_id="app-one-id", state="RUNNING"),
+        make_app("app-two", app_id="app-two-id", state="RUNNING"),
+    ]
 
 
 class ScheduleFilterBehaviorTest(unittest.TestCase):
     def test_schedule_include_app_ids_limits_updates_by_app_id(self):
-        client = run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
+        result = run_main({"apps": _apps()}, {"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
 
-        self.assertEqual(client.upgraded_apps, ["app-two"])
+        self.assertEqual(result.client.upgraded_apps, ["app-two"])
 
     def test_schedule_exclude_app_ids_skips_matching_app_ids(self):
-        client = run_main({"SCHEDULE_EXCLUDE_APP_IDS": "app-one-id"})
+        result = run_main({"apps": _apps()}, {"SCHEDULE_EXCLUDE_APP_IDS": "app-one-id"})
 
-        self.assertEqual(client.upgraded_apps, ["app-two"])
+        self.assertEqual(result.client.upgraded_apps, ["app-two"])
 
     def test_schedule_filters_use_id_not_name(self):
-        client = run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two"})
+        # Passing a name where an id is expected matches nothing.
+        result = run_main({"apps": _apps()}, {"SCHEDULE_INCLUDE_APP_IDS": "app-two"})
 
-        self.assertEqual(client.upgraded_apps, [])
+        self.assertEqual(result.client.upgraded_apps, [])
 
     def test_user_exclude_apps_still_applies_with_schedule_include_ids(self):
-        client = run_main({
-            "EXCLUDE_APPS": "app-two",
-            "SCHEDULE_INCLUDE_APP_IDS": "app-two-id",
-        })
+        result = run_main(
+            {"apps": _apps()},
+            {
+                "EXCLUDE_APPS": "app-two",
+                "SCHEDULE_INCLUDE_APP_IDS": "app-two-id",
+            },
+        )
 
-        self.assertEqual(client.upgraded_apps, [])
+        self.assertEqual(result.client.upgraded_apps, [])
 
     def test_schedule_include_and_exclude_ids_cannot_be_combined(self):
         with self.assertRaises(SystemExit) as raised:
-            run_main({
-                "SCHEDULE_INCLUDE_APP_IDS": "app-one-id",
-                "SCHEDULE_EXCLUDE_APP_IDS": "app-two-id",
-            })
+            run_main(
+                {"apps": _apps()},
+                {
+                    "SCHEDULE_INCLUDE_APP_IDS": "app-one-id",
+                    "SCHEDULE_EXCLUDE_APP_IDS": "app-two-id",
+                },
+            )
 
         self.assertEqual(raised.exception.code, 1)
-        self.assertEqual(FakeClient.instances, [])
+        self.assertEqual(ConfigurableClient.instances, [])
 
     def test_warns_when_scheduled_app_id_matches_no_app(self):
         with self.assertLogs("__main__", level="WARNING") as captured:
-            run_main({"SCHEDULE_INCLUDE_APP_IDS": "does-not-exist"})
+            run_main({"apps": _apps()}, {"SCHEDULE_INCLUDE_APP_IDS": "does-not-exist"})
 
         self.assertTrue(
             any("does-not-exist" in message for message in captured.output)
         )
 
     def test_does_not_warn_when_scheduled_app_id_exists(self):
-        with self.assertLogs("__main__", level="WARNING") as captured:
-            run_main({"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
-            import logging
-
-            logging.getLogger("__main__").warning("sentinel")
-
-        self.assertFalse(
-            any("does not match any TrueNAS app" in message for message in captured.output)
-        )
+        with self.assertNoLogs("__main__", level="WARNING"):
+            run_main({"apps": _apps()}, {"SCHEDULE_INCLUDE_APP_IDS": "app-two-id"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds support for per-app update schedules while preserving the existing global `CRON_SCHEDULE` behavior.

- Adds `APP_SCHEDULES`, a JSON map of TrueNAS app IDs to cron expressions.
- Generates cron entries at container startup so the container only wakes for configured schedules.
- Keeps existing `INCLUDE_APPS` and `EXCLUDE_APPS` as user-facing app-name filters.
- Adds internal ID-based schedule filters for generated cron runs.
- Adds optional `RUN_ON_START=true` for an immediate update check before cron starts.
- Replaces the static cron template with generated cron output.
- Adds unit tests and a GitHub Actions workflow for PR test coverage.

## Behavior

With:

```bash
APP_SCHEDULES='{"plex":"0 3 * * *","immich":"30 4 * * 0"}'
CRON_SCHEDULE="0 4 * * *"
```

cron entries are generated so:

- `plex` runs on its custom schedule.
- `immich` runs on its custom schedule.
- apps without custom schedules run on the global schedule.
- custom-scheduled app IDs are excluded from the global fallback run.

If `APP_SCHEDULES` is set without `CRON_SCHEDULE`, only explicitly scheduled apps run. Missed runs follow normal cron semantics; `RUN_ON_START=true` can run one check when the container starts.

## Validation

Ran locally:

```bash
python3 -m unittest discover -s tests
python3 -m py_compile app/main.py app/generate_crontab.py
bash -n docker-entrypoint.sh run-script.sh
git diff --check
```

All checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-app cron scheduling via `APP_SCHEDULES` (uses app IDs for schedule include/exclude filtering).
  * Added `RUN_ON_START` to trigger an immediate update check when scheduled mode is enabled.
* **Bug Fixes**
  * Scheduled mode now generates cron when `CRON_SCHEDULE` or `APP_SCHEDULES` is set, and falls back to a direct run if no cron entries are produced.
* **Documentation**
  * Updated scheduling documentation and examples in the README.
* **Tests**
  * Added/expanded unit and lifecycle coverage for schedule generation and schedule-based filtering.
* **Chores**
  * Added a CI workflow to run tests and validate Python and shell syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->